### PR TITLE
Fix language stats of the repository on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+
+# Force .jsm files to be classified as javascript files instead of 'Java'
+# this is made for github show a proper language in repo homepage
+# see https://github.com/github/linguist/issues/2377
+
+*.jsm linguist-language=Javascript

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-
-# Force .jsm files to be classified as javascript files instead of 'Java'
-# this is made for github show a proper language in repo homepage
-# see https://github.com/github/linguist/issues/2377
-
-*.jsm linguist-language=Javascript

--- a/content/oldScriptsImporter.jsm
+++ b/content/oldScriptsImporter.jsm
@@ -1,4 +1,4 @@
-/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* -*- Mode: Javascript; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab filetype=javascript: */
 
 'use strict';

--- a/content/ui.jsm
+++ b/content/ui.jsm
@@ -1,4 +1,4 @@
-/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* -*- Mode: Javascript; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab filetype=javascript: */
 
 'use strict';


### PR DESCRIPTION
On repo homepage you can notice that Java language is displayed in stats. This is a fix for that.

(here is a example of what I mean by the language stats indicator)

![language stats bar](https://cloud.githubusercontent.com/assets/173/5562290/48e24654-8ddf-11e4-8fe7-735b0ce3a0d3.png)